### PR TITLE
Make tests pass when using JDK9+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ cache:
   directories:
   - $HOME/.m2
 
+env:
+  global:
+    - LEIN_USE_BOOTCLASSPATH=no
+
 script:
   - lein checks
   - lein tests

--- a/project.clj
+++ b/project.clj
@@ -15,12 +15,13 @@
 
   :profiles
   {:dev
-   {:dependencies [[org.clojure/clojure "1.9.0"]
-                   [org.clojure/clojurescript "1.9.946"]
+   {:dependencies [[org.clojure/clojure "1.10.0"]
+                   [org.clojure/clojurescript "1.10.520"]
                    [viebel/codox-klipse-theme "0.0.5"]]}
    :1.7  {:dependencies [[org.clojure/clojure "1.7.0"]]}
    :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
-   :1.9  {:dependencies [[org.clojure/clojure "1.9.0"]]}}
+   :1.9  {:dependencies [[org.clojure/clojure "1.9.0"]]}
+   :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]]}}
   :cljsbuild {:builds {:test
                        {:source-paths ["src" "test"]
                         :compiler {:output-to "target/test.js"
@@ -61,7 +62,7 @@
   :middleware [ultra.plugin/middleware]
 
   :aliases {"checks" ["do" "check" ["cljfmt" "check"] "eastwood"]
-            "tests" ["with-profile" "+1.9:+1.8:+1.7" "test"]
+            "tests" ["with-profile" "+1.10:+1.9:+1.8:+1.7" "test"]
             "docs" ["do"
                     ["shell" "dev-resources/prepare-docs.sh" "target/docs"]
                     "codox"

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                                    :target :nodejs}}}}
 
   :plugins [;; Nice test output
-            [venantius/ultra "0.5.2"]
+            [venantius/ultra "0.6.0"]
 
             ;; Clojurescript tests
             [lein-doo "0.1.8"]
@@ -82,7 +82,7 @@
                   ["vcs" "push"]
                   ["deploy-docs"]]
 
-  :repositories [["clojars" {:url "https://clojars.org"
+  :repositories [["clojars" {:url "https://repo.clojars.org"
                              :creds :gpg}]]
 
   :deploy-repositories [["releases" :clojars]]


### PR DESCRIPTION
This makes the lein configuration work when using JDK9+ by updating the venantius/ultra dependency to 0.6.0 and setting the LEIN_USE_BOOTCLASSPATH env variable to "no", as described in https://github.com/venantius/ultra/issues/108.

Also required changing the clojars repo URL to https://repo.clojars.org to make dependency resolution work.