### PR TITLE
Add `:require-macros` to cljc namespaces

### DIFF
--- a/src/same.cljc
+++ b/src/same.cljc
@@ -2,7 +2,9 @@
 ;; Licensed under the MIT License.
 (ns same
   {:deprecated "0.1.5" :superseded-by "same.core"}
-  (:require [same.core]))
+  (:require [same.core])
+  #?(:cljs
+     (:require-macros [same])))
 
 (def ish? same.core/ish?)
 (def zeroish? same.core/zeroish?)

--- a/src/same/core.cljc
+++ b/src/same/core.cljc
@@ -5,7 +5,9 @@
   (:require #?(:clj [clojure.test :refer [assert-expr do-report]])
             #?(:clj [same.diff :as diff])
             [same.compare :refer [near-zero]]
-            [same.ish :as ish :refer [ish]]))
+            [same.ish :as ish :refer [ish]])
+  #?(:cljs
+     (:require-macros [same.core])))
 
 (defn ish?
   "Compare one or more values to an expected value, returning true if they are the same-ish.

--- a/test/same/core_test.cljc
+++ b/test/same/core_test.cljc
@@ -2,9 +2,7 @@
 ;; Licensed under the MIT License.
 (ns same.core-test
   (:require [clojure.test :refer [deftest is testing]]
-            #?(:clj  [same.core :refer [ish? zeroish? not-zeroish? set-comparator! with-comparator]]
-               :cljs [same.core :refer [ish? zeroish? not-zeroish? set-comparator!]
-                      :refer-macros [with-comparator]])
+            [same.core :refer [ish? zeroish? not-zeroish? set-comparator! with-comparator]]
             [same.ish :as ish]
             [same.platform :as p]
             [same.test-helpers :refer [about infinity #?@(:clj [java-map java-set])]]))

--- a/test/same_test.cljc
+++ b/test/same_test.cljc
@@ -3,9 +3,7 @@
 (ns same-test
   "Deprecated in favor of same.core-test."
   (:require [clojure.test :refer [deftest is testing]]
-            #?(:clj  [same :refer [ish? zeroish? not-zeroish? set-comparator! with-comparator]]
-               :cljs [same :refer [ish? zeroish? not-zeroish? set-comparator!]
-                      :refer-macros [with-comparator]])
+            [same :refer [ish? zeroish? not-zeroish? set-comparator! with-comparator]]
             [same.ish :as ish]
             [same.platform :as p]
             [same.test-helpers :refer [about infinity #?@(:clj [java-map java-set])]]))


### PR DESCRIPTION
I love the library and use it everywhere in https://github.com/sicmutils/sicmutils.

The only issue I have is that to use the macros via `cljs`, I have to add `:include-macros true` to my `require` form: https://github.com/sicmutils/sicmutils/blob/b48ef1f73055b8dd845c91c9e300cec150b014e4/test/sicmutils/numerical/unimin/bracket_test.cljc#L8

The change in this PR removes that need for library consumers, tidying up the `require`-side API.